### PR TITLE
Adicionado itens e build para Insurgente de Explosão Antimatéria

### DIFF
--- a/assets/js/cartas.js
+++ b/assets/js/cartas.js
@@ -685,6 +685,19 @@ var cartas = [
     }
   },
   {
+    cartaID:     "27182",
+    cartaNome:   "Carta Ferlock",
+    cartaSlot:   "itemArma",
+    cartaClasses: ["todas"],
+    itemBonus: ["REQ_Explosao_Antimateria"],
+    itemFuncao: function(slot, itemId, tipoItem) {
+      return {
+        "atq": 30,
+        "danode--Explosao_Antimateria": 30 + (getItemRefino(slot) >= 10 ? 30 : 0)
+      }
+    }
+  },
+  {
     cartaID:     "4080",
     cartaNome:   "Carta Flora",
     cartaSlot:   "itemArma",

--- a/assets/js/classes.js
+++ b/assets/js/classes.js
@@ -1768,6 +1768,29 @@ var classes = [
         },
         requisitos: ["REQ_Aspd","REQ_DFisico","REQ_DDist","REQ_IgnDef","REQ_Tiro_Neutralizante","REQ_CFix","REQ_CVar","REQ_Pos"]
       },
+      {
+        id: "Explosao_Antimateria",
+        nome: "Explosão Antimatéria",
+        maoDireita: ["Arma_Rifle"],
+        maoEsquerda: [],
+        ataque: {
+          tipoDano: "fisico",
+          distancia: "longa",
+          tipoAtaque: "skill",
+          propriedade: false,
+          conjuracaovariavel: 2,
+          conjuracaofixa: 1,
+          posconjuracao: 1,
+          recarga: 5
+        },
+        golpes: function(prop, nivelBase, nivelClasse, tipoArma) {
+          return [1, 1]
+        },
+        formula: function(prop, nivelBase, nivelClasse, tipoArma) {
+          return (5000)
+        },
+        requisitos:  ["REQ_Aspd","REQ_DFisico","REQ_DDist","REQ_IgnDef","REQ_Explosao_Antimateria","REQ_CFix","REQ_CVar","REQ_Pos"]
+      }
     ]
   },
   {

--- a/assets/js/itemBonuses.js
+++ b/assets/js/itemBonuses.js
@@ -339,6 +339,14 @@ let itemBonuses = {
     "nome": "Dano de Cópia Explosiva",
     "porcentagem": true
   },
+  "danode--Explosao_Antimateria": {
+    "nome": "Dano de Explosão Antimatéria",
+    "porcentagem": true
+  },
+  "recargade--Explosao_Antimateria": {
+    "nome": "Recarga de Explosão Antimatéria",
+    "porcentagem": false
+  },
   "danode--Laminas_Retalhadoras": {
     "nome": "Dano de Lâminas Retalhadoras",
     "porcentagem": true

--- a/assets/js/itens.js
+++ b/assets/js/itens.js
@@ -40,6 +40,25 @@ let encantamentosMonarca = ["4700", "4701", "4702", "4703", "4730", "4731", "473
 
 var items = [
   {
+    itemId:     "810012",
+    itemNome:   "[MEGA] A.R.-89 [1]",
+    itemTipo:   "itemArma",
+    itemSubtipo: "Arma_Rifle",
+    itemArmaATQ: 170,
+    itemArmaNivel: 4,
+    itemNivel:  100,
+    itemPropriedade: 0,
+    itemClasses: ["Classe_IN"],
+    itemBonus: ["REQ_DFisico","REQ_DDist","REQ_SP","REQ_Explosao_Antimateria"],
+    slots: 1,
+    itemFuncao: function(slot, itemId, tipoItem) {
+      return {
+        "danofisicop": Math.min(getItemRefino(slot) * 10, 100),
+        "conjuracaofixap": (isClasse("Classe_IN") ? -100 : 0),
+      }
+    }
+  },
+  {
     itemId:     "450158",
     itemNome:   "[MEGA] Robe Gelado [1]",
     itemTipo:   "itemArmadura",
@@ -10063,6 +10082,25 @@ var items = [
         "atributodestreza": getItemRefino(slot) >= 10 ? 10 : 0,
         "atributosorte": getItemRefino(slot) >= 10 ? 10 : 0,
         "atributosorte": (getItemRefino(slot) >= 10 ? 10 : 0) + (getItemRefino(slot) >= 12 ? 15 : 0),
+      }
+    }
+  },
+  {
+    itemId:     "410186",
+    itemNome:   "Relógio de Bolso dos Rebeldes [1]",
+    itemTipo:   "itemMeio",
+    itemNivel:  100,
+    itemClasses: ["todas"],
+    itemBonus: ["REQ_Explosao_Antimateria","REQ_Pos","REQ_DFisico"],
+    slots: 1,
+    encantamentos: [
+      ["4700","4730","4740","4710","4720","4750"]
+    ],
+    itemFuncao: function(slot, itemId, tipoItem) {
+      return {
+        "danofisicotamanho": 10,
+        "recargade--Explosao_Antimateria": (isClasse("Classe_IN") ? -5 : 0),
+        "posconjuracao": (isClasse("Classe_IN") ? -15 : 0)
       }
     }
   },


### PR DESCRIPTION
- Adicionado nova build para Insurgente: [Explosão Antimatéria](https://browiki.org/wiki/Explos%C3%A3o_Antimat%C3%A9ria)
- Adicionado [Carta Ferlock](https://www.divine-pride.net/database/item/27182/carta-ferlock):
- Adicionado [[MEGA] A.R.-89 [1]](https://www.divine-pride.net/database/item/810012/mega-a-r-89-1)
- Adicionado [Relógio de Bolso dos Rebeldes [1]](https://www.divine-pride.net/database/item/410186/relogio-de-bolso-dos-rebeldes-1)

![image](https://github.com/user-attachments/assets/26f1c41c-5aeb-46d3-9caf-56b9af91e117)
![image](https://github.com/user-attachments/assets/53c91d0e-a9f6-4094-82dc-24bfd6acf100)
![image](https://github.com/user-attachments/assets/c88695e6-ecc9-4050-b187-e16a6e9b891c)
![image](https://github.com/user-attachments/assets/7990a8f5-5bf2-4efe-b587-13319580987e)
